### PR TITLE
Add option to programmatically disable plugin

### DIFF
--- a/src/helmet.ts
+++ b/src/helmet.ts
@@ -43,6 +43,7 @@ type SetHeaderFunction = (header: readonly [string, string]) => void;
 type RemoveHeaderFunction = (name: string) => void;
 
 export type HelmetOptions = {
+  enabled?: boolean;
   seed?: string;
   aot?: boolean;
   contentSecurityPolicy?: ContentSecurityPolicyOptions | boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,12 @@ import Elysia from 'elysia';
 import { HelmetOptions, setHelmetHeaders } from './helmet';
 
 export const helmet = (options: Readonly<HelmetOptions> = {}) => {
+  if (options.enabled === false) {
+    return new Elysia({
+      name: 'elysia-helmet',
+      seed: options.seed ?? '',
+    });
+  }
   return new Elysia({
     name: 'elysia-helmet',
     seed: options.seed ?? '',


### PR DESCRIPTION
The idiomatic way to disable plugins in Elysia is with an `enabled` property on the configuration object. This will allow an easy and idiomatic way to programmatically disable the plugin, such as in non-production environments or when the plugin is misbehaving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to disable helmet security headers when initializing the service.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->